### PR TITLE
Add circular board layout

### DIFF
--- a/src/components/GameBoard.svelte
+++ b/src/components/GameBoard.svelte
@@ -2,12 +2,12 @@
 <script lang="ts">
   import BoardCase from "./BoardCase.svelte";
   import Pawn from "./Pawn.svelte";
-  import { generateSpiralCases } from "$lib/logic/generateSpiralCases";
+  import { generateCircularCases } from "$lib/logic/generateCircularCases";
 
   export let total = 64;
   export let currentPosition = 0;
 
-  const cases = generateSpiralCases(total);
+  const cases = generateCircularCases(total);
 </script>
 
 <svg viewBox="0 0 500 500" width="100%" height="auto">

--- a/src/lib/logic/generateCircularCases.ts
+++ b/src/lib/logic/generateCircularCases.ts
@@ -1,0 +1,44 @@
+export interface CaseData {
+  id: number;
+  x: number;
+  y: number;
+  color: string;
+  icon?: string;
+}
+
+export function generateCircularCases(
+  total: number,
+  centerX = 250,
+  centerY = 250,
+  radius = 200
+): CaseData[] {
+  const cases: CaseData[] = [];
+  const angleStep = (2 * Math.PI) / total;
+
+  for (let i = 0; i < total; i++) {
+    const angle = i * angleStep;
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
+
+    cases.push({
+      id: i,
+      x,
+      y,
+      color: pickColor(i),
+      icon: pickIcon(i),
+    });
+  }
+
+  return cases;
+}
+
+function pickColor(i: number): string {
+  const colors = ["#3B82F6", "#F59E0B", "#10B981", "#EF4444", "#6B21A8"];
+  return colors[i % colors.length];
+}
+
+function pickIcon(i: number): string | undefined {
+  if (i % 7 === 0) return "🎲";
+  if (i % 11 === 0) return "⛈️";
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- add a circular board generator
- use the generator to display `GameBoard` cases around a circle

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6888dbabcb0c8329a3e6526ce956e8ed