### PR TITLE
Implement grid-based board

### DIFF
--- a/src/components/BoardCase.svelte
+++ b/src/components/BoardCase.svelte
@@ -1,16 +1,24 @@
-<!-- case individuelle -->
-
+<!-- case individuelle en grille -->
 <script lang="ts">
   export let id: number;
-  export let x: number;
-  export let y: number;
   export let color: string;
   export let icon: string | null | undefined = undefined;
 </script>
 
-<g transform={`translate(${x}, ${y})`}>
-  <rect width="36" height="36" rx="6" fill={color} stroke="black" />
-  <text x="18" y="24" text-anchor="middle" fill="white" font-size="16">
-    {icon ?? id + 1}
-  </text>
-</g>
+<div class="case" style="background-color: {color}">
+  {icon ?? id + 1}
+</div>
+
+<style>
+  .case {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid black;
+    border-radius: 6px;
+    color: white;
+    font-size: 16px;
+  }
+</style>

--- a/src/components/GameBoard.svelte
+++ b/src/components/GameBoard.svelte
@@ -1,21 +1,32 @@
-<!-- plateau principal -->
+<!-- plateau principal en grille -->
 <script lang="ts">
   import BoardCase from "./BoardCase.svelte";
   import Pawn from "./Pawn.svelte";
-  import { generateSnailCases } from "$lib/logic/generateSnailCases";
+  import { generateGooseBoard } from "$lib/logic/generateGooseBoard";
 
-  export let total = 64;
   export let currentPosition = 0;
 
-  const cases = generateSnailCases(total);
+  const cases = generateGooseBoard();
 </script>
 
-<svg viewBox="0 0 500 500" width="100%" height="auto">
+<div class="board">
   {#each cases as c (c.id)}
-    <BoardCase {...c} />
+    <BoardCase id={c.id} color={c.color} icon={c.icon} style="grid-row: {c.row}; grid-column: {c.col};" />
   {/each}
 
   {#if cases[currentPosition]}
-    <Pawn x={cases[currentPosition].x} y={cases[currentPosition].y} />
+    <Pawn row={cases[currentPosition].row} col={cases[currentPosition].col} />
   {/if}
-</svg>
+</div>
+
+<style>
+  .board {
+    display: grid;
+    grid-template-columns: repeat(10, 40px);
+    grid-template-rows: repeat(10, 40px);
+    gap: 4px;
+    width: fit-content;
+    margin: 0 auto;
+    position: relative;
+  }
+</style>

--- a/src/components/Pawn.svelte
+++ b/src/components/Pawn.svelte
@@ -1,14 +1,19 @@
 <!-- pion mobile -->
 <script lang="ts">
-  export let x: number;
-  export let y: number;
+  export let row: number;
+  export let col: number;
 </script>
 
-<circle
-  cx={x + 20}
-  cy={y + 20}
-  r="10"
-  fill="black"
-  stroke="white"
-  stroke-width="2"
-/>
+<div class="pawn" style="grid-row: {row}; grid-column: {col};"></div>
+
+<style>
+  .pawn {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: black;
+    border: 2px solid white;
+    justify-self: center;
+    align-self: center;
+  }
+</style>

--- a/src/lib/logic/generateGooseBoard.ts
+++ b/src/lib/logic/generateGooseBoard.ts
@@ -1,0 +1,72 @@
+export interface GridCaseData {
+  id: number;
+  row: number;
+  col: number;
+  color: string;
+  icon?: string;
+}
+
+export function generateGooseBoard(): GridCaseData[] {
+  const cases: GridCaseData[] = [];
+  let id = 0;
+
+  // Row 1: 1-10 left to right
+  for (let col = 1; col <= 10; col++) {
+    cases.push(makeCase(id++, 1, col));
+  }
+
+  // Row 2: case 11 at col 10
+  cases.push(makeCase(id++, 2, 10));
+
+  // Row 3: 12-21 right to left
+  for (let col = 10; col >= 1; col--) {
+    cases.push(makeCase(id++, 3, col));
+  }
+
+  // Row 4: case 22 at col 1
+  cases.push(makeCase(id++, 4, 1));
+
+  // Row 5: 23-32 left to right
+  for (let col = 1; col <= 10; col++) {
+    cases.push(makeCase(id++, 5, col));
+  }
+
+  // Row 6: case 33 at col 10
+  cases.push(makeCase(id++, 6, 10));
+
+  // Row 7: 34-43 right to left
+  for (let col = 10; col >= 1; col--) {
+    cases.push(makeCase(id++, 7, col));
+  }
+
+  // Row 8: case 44 at col 1
+  cases.push(makeCase(id++, 8, 1));
+
+  // Row 9: 45-50 left to right (only 6 cells visible)
+  for (let col = 1; col <= 6; col++) {
+    cases.push(makeCase(id++, 9, col));
+  }
+
+  return cases;
+}
+
+function makeCase(id: number, row: number, col: number): GridCaseData {
+  return {
+    id,
+    row,
+    col,
+    color: pickColor(id),
+    icon: pickIcon(id)
+  };
+}
+
+function pickColor(i: number): string {
+  const colors = ["#3B82F6", "#F59E0B", "#10B981", "#EF4444", "#6B21A8"];
+  return colors[i % colors.length];
+}
+
+function pickIcon(i: number): string | undefined {
+  if (i % 11 === 0) return "⛈️";
+  if (i % 7 === 0) return "🎲";
+  return undefined;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,7 @@
 </p>
 <p>Check the console for the list of categories loaded from Firebase.</p>
 
-<GameBoard total={64} currentPosition={5} />
+<GameBoard currentPosition={5} />
 
 <style>
   h1 {


### PR DESCRIPTION
## Summary
- implement goose board generator for 10x10 grid
- render board using CSS grid
- adapt board case and pawn to use HTML elements
- update page to use new board component

## Testing
- `npm run check` *(fails: `svelte-kit: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6889f24b073c832995519945b49d17f3