### PR TITLE
Implement grid-based board

### DIFF
--- a/src/components/BoardCase.svelte
+++ b/src/components/BoardCase.svelte
@@ -3,9 +3,14 @@
   export let id: number;
   export let color: string;
   export let icon: string | null = null;
+  export let row?: number;
+  export let col?: number;
 </script>
 
-<div class="case" style="background-color: {color}">
+<div
+  class="case"
+  style="background-color: {color}; grid-row: {row}; grid-column: {col};"
+>
   {icon ?? id + 1}
 </div>
 

--- a/src/components/GameBoard.svelte
+++ b/src/components/GameBoard.svelte
@@ -2,20 +2,29 @@
 <script lang="ts">
   import BoardCase from "./BoardCase.svelte";
   import Pawn from "./Pawn.svelte";
-  import { generateSnailCases } from "$lib/logic/generateSnailCases";
+  import { generateGooseBoard } from "$lib/logic/generateGooseBoard";
 
-  export let total = 64;
   export let currentPosition = 0;
 
-  const cases = generateSnailCases(total);
+  const cases = generateGooseBoard();
 </script>
 
-<svg viewBox="0 0 500 500" width="100%" height="auto">
+<div class="board">
   {#each cases as c (c.id)}
     <BoardCase {...c} />
   {/each}
 
   {#if cases[currentPosition]}
-    <Pawn x={cases[currentPosition].x} y={cases[currentPosition].y} />
+    <Pawn row={cases[currentPosition].row} col={cases[currentPosition].col} />
   {/if}
-</svg>
+</div>
+
+<style>
+  .board {
+    display: grid;
+    grid-template-columns: repeat(10, 40px);
+    grid-template-rows: repeat(10, 40px);
+    gap: 4px;
+    width: fit-content;
+  }
+</style>


### PR DESCRIPTION
## Summary
- support row and column props in BoardCase
- replace SVG board with grid-based layout using generateGooseBoard

## Testing
- `npm run check` *(fails: `svelte-kit: not found`)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6889f4a146b88329bcf7fe7205ff3872