### PR TITLE
Implement turn limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
 
+## Gameplay
+
+The Goose Game is played over a series of turns. On each turn you roll the dice and move your pawn forward.
+
+- The colour of the square indicates the question category. Categories are loaded from Firebase and associated with board colours.
+- If you answer incorrectly, you skip rolling on the next turn and must answer a new question instead.
+- After 10 turns the game ends and you lose.
+
+These rules are implemented in the Svelte application found in `src/routes/+page.svelte`.
+
 ## Creating a project
 
 If you're seeing this, you've probably already done this step. Congrats!

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,9 @@ import DiceRoller from "../components/DiceRoller.svelte";
 import { generateGooseBoard } from "$lib/logic/generateGooseBoard";
 
 let position = 0;
+let turns = 0;
+let gameOver = false;
+let message = '';
 const board = generateGooseBoard();
 
 onMount(async () => {
@@ -18,8 +21,15 @@ onMount(async () => {
   );
 });
 
-function handleRoll(event: { detail: { total: number; }; }) {
+function handleRoll(event: { detail: { total: number } }) {
+  if (gameOver) return;
+  turns += 1;
   position = Math.min(position + event.detail.total, board.length - 1);
+  message = `Tour ${turns}/10`;
+  if (turns >= 10) {
+    gameOver = true;
+    message = "10 tours écoulés. Vous avez perdu !";
+  }
 }
 </script>
 
@@ -32,7 +42,10 @@ function handleRoll(event: { detail: { total: number; }; }) {
 <p>Check the console for the list of categories loaded from Firebase.</p>
 
 <GameBoard currentPosition={position} />
-<DiceRoller on:rolled={handleRoll} />
+<p>{message}</p>
+{#if !gameOver}
+  <DiceRoller on:rolled={handleRoll} />
+{/if}
 
 <style>
   h1 {


### PR DESCRIPTION
## Summary
- add goose game instructions to the README
- stop the game after ten turns with a message

## Testing
- `npm run check` *(fails: `svelte-kit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2a60f5608329864c0c0d635ef7cc