### PR TITLE
Add question modal

### DIFF
--- a/src/components/QuestionModal.svelte
+++ b/src/components/QuestionModal.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  export let visible: boolean;
+  export let question: string = '';
+  const close = () => {
+    visible = false;
+    dispatch('close');
+  };
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+</script>
+
+{#if visible}
+<div class="overlay" on:click={close}>
+  <div class="modal" on:click|stopPropagation>
+    <p>{question}</p>
+    <button on:click={close}>Fermer</button>
+  </div>
+</div>
+{/if}
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .modal {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    max-width: 300px;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,12 +4,15 @@
   import { collection, getDocs } from "firebase/firestore";
   import GameBoard from "../components/GameBoard.svelte";
   import DiceRoller from "../components/DiceRoller.svelte";
+  import QuestionModal from "../components/QuestionModal.svelte";
   import { generateGooseBoard } from "$lib/logic/generateGooseBoard";
 
   let position = 0;
   let turns = 0;
   let gameOver = false;
   let message = "";
+  let showQuestion = false;
+  let currentQuestion = "";
   const board = generateGooseBoard();
 
   onMount(async () => {
@@ -21,11 +24,32 @@
     );
   });
 
-  function handleRoll(event: { detail: { total: number } }) {
+  async function fetchQuestion() {
+    const catRef = collection(db, "categories");
+    const catSnap = await getDocs(catRef);
+    if (catSnap.empty) {
+      currentQuestion = "Aucune catégorie trouvée.";
+      return;
+    }
+    const firstCat = catSnap.docs[0];
+    const qRef = collection(db, "categories", firstCat.id, "questions");
+    const qSnap = await getDocs(qRef);
+    if (qSnap.empty) {
+      currentQuestion = "Aucune question disponible.";
+      return;
+    }
+    const questionDoc = qSnap.docs[0];
+    currentQuestion =
+      questionDoc.get("text") ?? questionDoc.get("question") ?? "";
+  }
+
+  async function handleRoll(event: { detail: { total: number } }) {
     if (gameOver) return;
     turns += 1;
     position = Math.min(position + event.detail.total, board.length - 1);
     message = `Tour ${turns}/10`;
+    await fetchQuestion();
+    showQuestion = true;
     if (turns >= 10) {
       gameOver = true;
       message = "10 tours écoulés. Vous avez perdu !";
@@ -46,6 +70,7 @@
 {#if !gameOver}
   <DiceRoller on:rolled={handleRoll} />
 {/if}
+<QuestionModal visible={showQuestion} question={currentQuestion} on:close={() => (showQuestion = false)} />
 
 <style>
   h1 {


### PR DESCRIPTION
## Summary
- add a simple `QuestionModal` component
- fetch the first question from Firestore when the player lands on a case

## Testing
- `npm install` *(fails: network disabled)*
- `npm run check` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688a2eecc6b88329a07c46b23ecb384f