### PR TITLE
Add question validation to modal

### DIFF
--- a/src/components/QuestionModal.svelte
+++ b/src/components/QuestionModal.svelte
@@ -1,18 +1,61 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export interface QuestionData {
+    category: string;
+    question: string;
+    choices: string[];
+    answer: string;
+    explanation: string;
+  }
+
   export let visible: boolean;
-  export let question: string = '';
+  export let questionData: QuestionData | null = null;
+
+  const dispatch = createEventDispatcher();
+
+  let selected: string = '';
+  let validated = false;
+  let resultMessage = '';
+
   const close = () => {
     visible = false;
+    selected = '';
+    validated = false;
+    resultMessage = '';
     dispatch('close');
   };
-  import { createEventDispatcher } from 'svelte';
-  const dispatch = createEventDispatcher();
+
+  const validate = () => {
+    if (!questionData) return;
+    validated = true;
+    resultMessage =
+      selected === questionData.answer ? 'Bonne réponse !' : 'Mauvaise réponse !';
+  };
 </script>
 
-{#if visible}
+{#if visible && questionData}
 <div class="overlay" on:click={close}>
   <div class="modal" on:click|stopPropagation>
-    <p>{question}</p>
+    <h2>{questionData.category}</h2>
+    <p>{questionData.question}</p>
+
+    <form>
+      {#each questionData.choices as choice}
+        <label class="choice">
+          <input type="radio" bind:group={selected} value={choice} disabled={validated} />
+          {choice}
+        </label>
+      {/each}
+    </form>
+
+    {#if !validated}
+      <button on:click={validate} disabled={selected === ''}>Valider</button>
+    {:else}
+      <p class="result">{resultMessage}</p>
+      <p class="explanation">{questionData.explanation}</p>
+    {/if}
+
     <button on:click={close}>Fermer</button>
   </div>
 </div>
@@ -32,5 +75,17 @@
     padding: 20px;
     border-radius: 8px;
     max-width: 300px;
+  }
+  .choice {
+    display: block;
+    margin-bottom: 8px;
+  }
+  .result {
+    font-weight: bold;
+    margin-top: 10px;
+  }
+  .explanation {
+    font-style: italic;
+    margin-top: 4px;
   }
 </style>


### PR DESCRIPTION
## Summary
- display category title and choices in QuestionModal
- allow users to select an answer and validate it
- show success/failure message with explanation
- update page logic to fetch full question details from Firebase

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b800760a083299bee10576db15a12